### PR TITLE
refactor `export` to `export_to`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1411,8 +1411,8 @@ impl<'a> Mailbox<'a> {
         }
     }
 
-    /// Exports a [CapabilityRef] to a [Table]
-    pub fn export<'b>(
+    /// Exports a [CapabilityRef] to a [Table].
+    pub fn export_to<'b>(
         &self,
         perms: Permissions,
         table: &'b Table,
@@ -1427,6 +1427,11 @@ impl<'a> Mailbox<'a> {
         });
 
         Ok(CapabilityRef { table, handle })
+    }
+
+    /// Exports a [CapabilityRef] to the current mailbox's [Table].
+    pub fn export(&self, perms: Permissions) -> TableResult<CapabilityRef<'a>> {
+        self.export_to(perms, self.group.table)
     }
 
     /// Exports an [OwnedCapability] from this mailbox.

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -26,7 +26,7 @@ async fn send_message() {
     let table = Table::default();
     let group = MailboxGroup::new(&table);
     let mb = group.create_mailbox().unwrap();
-    let ad = mb.export_to(Permissions::SEND, &table).unwrap();
+    let ad = mb.export(Permissions::SEND).unwrap();
     ad.send(b"Hello world!", &[]).await.unwrap();
 
     assert!(mb


### PR DESCRIPTION
Changes `export` to `export_to`.
Makes `export` export to the mailbox's table.
closes #10
